### PR TITLE
Draft: Allow failures for exploding gradients.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ctan/
+__pycache__/

--- a/confs/conf_tgb_link_prediction.py
+++ b/confs/conf_tgb_link_prediction.py
@@ -1,5 +1,6 @@
 from utils import cartesian_product
 from models import *
+from models.ctdg_models import CTAN_tgb
 
 
 wiki = {  

--- a/main_tgb_ctan.py
+++ b/main_tgb_ctan.py
@@ -193,6 +193,7 @@ if __name__ == "__main__":
     parser.add_argument('--validation_batched', help='In validation, whether to batch samples before forward.', action='store_true')
 
     parser.add_argument('--cluster', help='Experiments run on a cluster.', action='store_true')
+    parser.add_argument('--slurm', action='store_true')
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--parallelism', help='The degree of parallelism, ie, maximum number of parallel jobs.', default=None, type=int)
     parser.add_argument('--overwrite_ckpt', help='Overwrite checkpoint.', action='store_true')
@@ -272,7 +273,7 @@ if __name__ == "__main__":
     
     # Run model selection 
     model_instance, get_conf = MODEL_CONFS[args.model]
-    conf_list = list(get_conf(num_nodes, edge_dim, node_dim, out_dim, init_time, mean_delta_t, std_delta_t, {}))
+    conf_list = list(get_conf(num_nodes, edge_dim, node_dim, out_dim, init_time, mean_delta_t, std_delta_t))
     df = run_configs(
         conf_list = conf_list,
         args = args, 

--- a/models/ctdg_models.py
+++ b/models/ctdg_models.py
@@ -496,9 +496,13 @@ class CTAN_tgb(CTAN):
                  # Distinguish between link prediction and sequence prediction
                  predict_dst: bool = False,
                  # conv type Transformer
-                 conv_type: str = 'TransformerConv'
+                 conv_type: str = 'TransformerConv',
+                 separable: bool = False,
+                 layernorm: bool = None
         ):
         super().__init__(num_nodes, edge_dim, memory_dim, time_dim, node_dim, num_iters, gnn_act, gnn_act_kwargs, epsilon, gamma, readout_hidden, readout_out, mean_delta_t, std_delta_t, init_time, final_act, predict_dst, conv_type)
+        self.separable = separable
+        self.layernorm = layernorm
         self.readout = TGBLinkPredictor(memory_dim)
 
     def forward(self, batch, n_id, msg, t, edge_index, id_mapper):

--- a/models/ctdg_models.py
+++ b/models/ctdg_models.py
@@ -498,11 +498,11 @@ class CTAN_tgb(CTAN):
                  # conv type Transformer
                  conv_type: str = 'TransformerConv',
                  separable: bool = False,
-                 layernorm: bool = None
+                 layernorm: bool = False
         ):
         super().__init__(num_nodes, edge_dim, memory_dim, time_dim, node_dim, num_iters, gnn_act, gnn_act_kwargs, epsilon, gamma, readout_hidden, readout_out, mean_delta_t, std_delta_t, init_time, final_act, predict_dst, conv_type)
         self.separable = separable
-        self.layernorm = layernorm
+        self.layernorm = torch.nn.LayerNorm(memory_dim) if layernorm else None
         self.readout = TGBLinkPredictor(memory_dim)
 
     def forward(self, batch, n_id, msg, t, edge_index, id_mapper):


### PR DESCRIPTION
This will allow ray runs to fail with `RunTimeError`. The issues we were seeing are due to exploding gradients - happens for some combinations of learning rate and `num_iters`.

Don't merge yet, I'd like to test other scripts too.